### PR TITLE
Support the AWS CLI's configuration file

### DIFF
--- a/bin/kumogata
+++ b/bin/kumogata
@@ -23,7 +23,12 @@ begin
     aws_opts[key] = options[key] if options[key]
   end
 
-  AWS.config(aws_opts) unless aws_opts.empty?
+  profile = options.fetch(:profile, :default)
+  if AWSConfig.has_profile?(profile)
+    AWS.config(AWSConfig[profile].config_hash)
+  else
+    AWS.config(aws_opts) unless aws_opts.empty?
+  end
 
   String.colorize = options.color?
   Diffy::Diff.default_format = options.color? ? :color : :text

--- a/kumogata.gemspec
+++ b/kumogata.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-sdk'
+  spec.add_dependency 'aws_config', '>= 0.0.2'
   spec.add_dependency 'coderay'
   spec.add_dependency 'diffy'
   spec.add_dependency 'dslh', '>= 0.2.6'

--- a/lib/kumogata.rb
+++ b/lib/kumogata.rb
@@ -2,6 +2,7 @@ module Kumogata; end
 require 'kumogata/version'
 
 require 'aws-sdk'
+require 'aws_config'
 require 'base64'
 require 'coderay'
 require 'diffy'

--- a/lib/kumogata/argument_parser.rb
+++ b/lib/kumogata/argument_parser.rb
@@ -80,6 +80,7 @@ class Kumogata::ArgumentParser
       update_usage(opt)
 
       begin
+        opt.on(''  , '--profile CONFIG_PROFILE')                {|v| options[:profile]                       = v     }
         opt.on('-k', '--access-key ACCESS_KEY')                 {|v| options[:access_key_id]                 = v     }
         opt.on('-s', '--secret-key SECRET_KEY')                 {|v| options[:secret_access_key]             = v     }
         opt.on('-r', '--region REGION')                         {|v| options[:region]                        = v     }


### PR DESCRIPTION
This patch adds a feature of configuring AWS credentials and region by _AWS CLI_'s configuration file.

http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html

This feature is implemented by using great _[aws_config](https://github.com/a2ikm/aws_config)_ library because of lack of this functionality in _aws-sdk_ (upcoming [aws-sdk-core](https://github.com/aws/aws-sdk-core-ruby) V2 will [support it](https://github.com/aws/aws-sdk-ruby/issues/477)).

It also add a `--profile` option to choose one of multiple profiles in the configuration file.
