### PR TITLE
support aws named profile `[profile name]` style.

### DIFF
--- a/lib/kumogata/config_parser.rb
+++ b/lib/kumogata/config_parser.rb
@@ -22,7 +22,7 @@ class Kumogata::ConfigParser
       next if line.empty?
 
       if line =~ /\A\[(.+)\]\z/
-        profile_name = $1
+        profile_name = $1.split.last
       elsif profile_name
         key, value = line.split('=', 2).map {|i| i.strip }
         @profiles[profile_name] ||= {}

--- a/spec/kumogata_config_parser_spec.rb
+++ b/spec/kumogata_config_parser_spec.rb
@@ -13,6 +13,11 @@ aws_access_key_id = xAKIAIOSFODNN7EXAMPLE
 aws_secret_access_key = xwJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 aws_security_token = xtexample123324
 
+[profile profile3]
+aws_access_key_id = xAKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = xwJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_security_token = xtexample123324
+
 [invalid]
     EOS
 
@@ -27,6 +32,12 @@ aws_security_token = xtexample123324
       )
 
       expect(subject['profile2']).to eq(
+        'aws_access_key_id' => 'xAKIAIOSFODNN7EXAMPLE',
+        'aws_secret_access_key' => 'xwJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        'aws_security_token' => 'xtexample123324',
+      )
+
+      expect(subject['profile3']).to eq(
         'aws_access_key_id' => 'xAKIAIOSFODNN7EXAMPLE',
         'aws_secret_access_key' => 'xwJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
         'aws_security_token' => 'xtexample123324',


### PR DESCRIPTION
Hi,

The `--profile` option should be work like aws cli. 

For example, here is sample config from [Setting and Using Named Profiles  | AWS Command Line Interface
User Guide](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles)

```
[default]
aws_access_key_id=AKIAIOSFODNN7EXAMPLE
aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
region=us-east-1

[profile test-user]
aws_access_key_id=AKIAI44QH8DHBEXAMPLE
aws_secret_access_key=je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
region=us-west-2
```

In this case, the kumogata have to be give option as `--profile 'profile test-user'` to pass profile name.
I would like to pass profile name with option `--profile test-user`.
