### PR TITLE
enable --capabilities option for update command

### DIFF
--- a/lib/kumogata/client.rb
+++ b/lib/kumogata/client.rb
@@ -521,6 +521,11 @@ class Kumogata::Client
   def build_update_options(template)
     opts = {:template => template}
     add_parameters(opts)
+
+    [:capabilities].each do |k|
+      opts[k] = @options[k] if @options[k]
+    end
+
     return opts
   end
 


### PR DESCRIPTION
IAM Roleリソースを含むstackを `kumogata update --capabilities CAPABILITY_IAM 後略` しようとしたところ

```
Requires capabilities : [CAPABILITY_IAM]
```

と怒られてしまったので、 `create` 時と同様に `--capabilities` オプションを反映するようにしてみたところ動きました。

`:disable_rollback, :notify, :timeout` はひとまず保留にしていますが、同様に反映できるのかもしれません。

SDKのReferenceが不親切案件ですね……