### PR TITLE
add output validate result

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Options:
         --color
         --no-color
         --debug
+    -v, --verbose
 ```
 
 ### KUMOGATA_OPTIONS

--- a/lib/kumogata/argument_parser.rb
+++ b/lib/kumogata/argument_parser.rb
@@ -107,6 +107,7 @@ class Kumogata::ArgumentParser
         opt.on(''  , '--color')                                    {    options[:color]                   = true  }
         opt.on(''  , '--no-color')                                 {    options[:color]                   = false }
         opt.on(''  , '--debug')                                    {    options[:debug]                   = true  }
+        opt.on('-v', '--verbose')                                  {    options[:verbose]                 = true  }
         opt.parse!
 
         unless (command = ARGV.shift)

--- a/lib/kumogata/client.rb
+++ b/lib/kumogata/client.rb
@@ -594,6 +594,9 @@ class Kumogata::Client
     end
 
     Kumogata.logger.info('Template validated successfully'.green)
+    if @options.verbose
+      Kumogata.logger.info(JSON.pretty_generate(JSON.parse(result.to_json)).colorize_as(:json))
+    end
   end
 
   def events_for(stack)


### PR DESCRIPTION
validateを実行した際に、Parametersの出力が欲しかったので追加しました。
`-v` または `--verbose` オプションを付与したときのみ出力するようにしています。

```
% ./kumogata validate test-template.rb -v
Template validated successfully
{
  "parameters": [
    {
      "no_echo": false,
      "parameter_key": "SSHLocation",
      "description": "The IP address range that can be used to SSH to the EC2 instances",
      "default_value": "0.0.0.0/0"
    },
    {
      "no_echo": false,
      "parameter_key": "YSjvzmVHBDCW079G",
      "default_value": "(YSjvzmVHBDCW079G)"
    },
    {
      "no_echo": false,
      "parameter_key": "InstanceType",
      "description": "WebServer EC2 instance type",
      "default_value": "m1.small"
    },
    {
      "no_echo": false,
      "parameter_key": "KeyName",
      "description": "Name of an existing EC2 KeyPair to enable SSH access to the instance"
    }
  ],
  "capabilities": [

  ],
  "description": "'skipfish' CloudFormation Template\nThis template create skipfish installed EC2 instance.\n",
  "response_metadata": {
    "request_id": "9a07f110-964c-11e4-a41c-019758cc6776"
  }
}
```