### PR TITLE
pass args and expand it in template via _include.

### DIFF
--- a/lib/kumogata/client.rb
+++ b/lib/kumogata/client.rb
@@ -291,7 +291,7 @@ class Kumogata::Client
 
   def define_template_func(scope, path_or_url)
     scope.instance_eval(<<-EOS)
-      def _include(file)
+      def _include(file, args = {})
         path = file.dup
 
         unless path =~ %r|\\A/| or path =~ %r|\\A\\w+://|


### PR DESCRIPTION
Hi!

I would like to pass args to template.

1:  write args(Hash) in template.

```
myEC2Instance do
  Type "AWS::EC2::Instance"
  Properties do
    ImageId args[:ami_id]
    InstanceType "t1.micro"
  end
end
```

2:  _include 1 with Hash.

It's optional, default value is {}.

```_include_with_hash
Resources do
  _include #{f.path.inspect}, {:ami_id => "ami-XXXXXXXX"}
end
```

3:  creates json with expanded args. 

```creates
{
  "Resources": {
    "myEC2Instance": {
      "Type": "AWS::EC2::Instance",
      "Properties": {
        "ImageId": "ami-XXXXXXXX",
        "InstanceType": "t1.micro"
      }
    }
  }
```