### PR TITLE
support stack policy

### DIFF
--- a/lib/kumogata/argument_parser.rb
+++ b/lib/kumogata/argument_parser.rb
@@ -88,6 +88,9 @@ class Kumogata::ArgumentParser
         opt.on(''  , '--profile CONFIG_PROFILE')                   {|v| options[:config_profile]          = v     }
         opt.on(''  , '--credentials-path PATH')                    {|v| options[:credentials_path]        = v     }
         opt.on(''  , '--config-path PATH')                         {|v| options[:config_path]             = v     }
+        opt.on(''  , '--stack-policy-body PATH')                   {|v| options[:stack_policy_body]       = File.read(v) }
+        opt.on(''  , '--stack-policy-url URL')                     {|v| options[:stack_policy_url]        = v     }
+
         opt.on(''  , '--format TMPLATE_FORMAT', supported_formats) {|v| options[:format]                  = v     }
         opt.on(''  , '--output-format FORMAT', supported_formats)  {|v| options[:output_format]           = v     }
         opt.on(''  , '--skip-replace-underscore')                  {    options[:skip_replace_underscore] = false }

--- a/lib/kumogata/client.rb
+++ b/lib/kumogata/client.rb
@@ -511,7 +511,8 @@ class Kumogata::Client
     opts = {}
     add_parameters(opts)
 
-    [:capabilities, :disable_rollback, :notify, :timeout].each do |k|
+    [:capabilities, :disable_rollback, :notify, :timeout,
+     :stack_policy_body, :stack_policy_url].each do |k|
       opts[k] = @options[k] if @options[k]
     end
 
@@ -522,7 +523,7 @@ class Kumogata::Client
     opts = {:template => template}
     add_parameters(opts)
 
-    [:capabilities].each do |k|
+    [:capabilities, :stack_policy_body, :stack_policy_url].each do |k|
       opts[k] = @options[k] if @options[k]
     end
 


### PR DESCRIPTION
Add new options `--stack-policy-body` and `--stack-policy-url` to
pass stack policy to prevent resource update.

AWS API document says CloudFormation supports "StackPolicyBody" and "StackPolicyUrl".
AWS SDK for Ruby lacks these documentation but actually possible.